### PR TITLE
Backend Edit and Delete user

### DIFF
--- a/backend/SocialNetwork.API/Controllers/AuthController.cs
+++ b/backend/SocialNetwork.API/Controllers/AuthController.cs
@@ -34,11 +34,7 @@ namespace SocialNetwork.API.Controllers
             return Ok(new LoginResponse { Token = token });
         }
 
-        [HttpDelete("logout")]
-        public IActionResult Logout()
-        {
-            return Ok("Logout successful.");
-        }
+        
 
         [HttpGet("validate")]
         [Authorize]
@@ -46,12 +42,60 @@ namespace SocialNetwork.API.Controllers
         {
             var userId = User.FindFirst("UserId")?.Value;
             var username = User.Identity?.Name;
-    
-             return Ok(new { 
-                 Valid = true, 
-                 UserId = userId,
-                    Username = username 
-                });
+
+            return Ok(new
+            {
+                Valid = true,
+                UserId = userId,
+                Username = username
+            });
         }
+
+        [HttpPut("edit-profile")]
+        [Authorize]
+        public async Task<IActionResult> EditProfile([FromBody] EditProfileRequest request)
+        {
+            var userId = User.FindFirst("UserId")?.Value;
+            if (userId == null)
+                return Unauthorized("User not found.");
+
+            var result = await _authService.EditProfileAsync(Guid.Parse(userId), request);
+            if (!result)
+                return BadRequest("Could not update profile.");
+
+            return Ok("Profile updated successfully.");
+        }
+        
+        [HttpDelete("delete-account")]
+        [Authorize]
+        public async Task<IActionResult> DeleteAccount()
+        {
+            var userId = User.FindFirst("UserId")?.Value;
+            if (userId == null)
+                return Unauthorized("User not found.");
+
+            var result = await _authService.DeleteAccountAsync(Guid.Parse(userId));
+            if (!result)
+                return BadRequest("Could not delete account.");
+
+            return Ok("Account deleted successfully.");
+        }
+
+        [HttpDelete("logout")]
+        public IActionResult Logout()
+        {
+            return Ok("Logout successful.");
+        }
+        
+        [HttpDelete("delete-user/{id}")]
+        public async Task<IActionResult> DeleteUserById(Guid id)
+        {
+            var result = await _authService.DeleteAccountAsync(id);
+            if (!result)
+                return NotFound("User not found or could not be deleted.");
+
+            return Ok("User deleted successfully.");
+        }
+
     }
 }

--- a/backend/SocialNetwork.Entity/Models/EditProfileRequest.cs
+++ b/backend/SocialNetwork.Entity/Models/EditProfileRequest.cs
@@ -1,0 +1,9 @@
+namespace SocialNetwork.Entity.Models
+{
+    public class EditProfileRequest
+    {
+        public string? Username { get; set; }
+        public string? Email { get; set; }
+        public string? Password { get; set; }
+    }
+}

--- a/backend/SocialNetwork.Entity/Models/SocialNetworkDbContext.cs
+++ b/backend/SocialNetwork.Entity/Models/SocialNetworkDbContext.cs
@@ -7,7 +7,7 @@ namespace SocialNetwork.Entity.Models
         public SocialNetworkDbContext(DbContextOptions<SocialNetworkDbContext> options)
             : base(options) { }
 
-        public DbSet<User> Users { get; set; }
+        public virtual DbSet<User> Users { get; set; }
         public DbSet<Follow> Follows { get; set; }
         public DbSet<Post> Posts { get; set; }
     }

--- a/backend/SocialNetwork.Repository/Services/AuthService.cs
+++ b/backend/SocialNetwork.Repository/Services/AuthService.cs
@@ -49,7 +49,8 @@ namespace SocialNetwork.Repository.Services
             new Claim("UserId", user.Id.ToString())
         };
 
-      var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]));
+      var jwtKey = _config["Jwt:Key"] ?? throw new InvalidOperationException("JWT key is not configured");
+      var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey));
       var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
       var token = new JwtSecurityToken(

--- a/backend/SocialNetwork.Repository/Services/AuthService.cs
+++ b/backend/SocialNetwork.Repository/Services/AuthService.cs
@@ -62,5 +62,38 @@ namespace SocialNetwork.Repository.Services
 
       return new JwtSecurityTokenHandler().WriteToken(token);
     }
+
+    public async Task<bool> DeleteAccountAsync(Guid userId)
+    {
+      var user = await _db.Users.FindAsync(userId);
+      if (user == null)
+        return false;
+
+      _db.Users.Remove(user);
+      await _db.SaveChangesAsync();
+      return true;
+    }
+
+    public async Task<bool> EditProfileAsync(Guid userId, EditProfileRequest request)
+    {
+      var user = await _db.Users.FindAsync(userId);
+      if (user == null)
+        return false;
+
+      if (!string.IsNullOrEmpty(request.Username))
+        user.Username = request.Username;
+
+      if (!string.IsNullOrEmpty(request.Email))
+        user.Email = request.Email;
+
+      if (!string.IsNullOrEmpty(request.Password))
+        user.Password = request.Password;
+
+      _db.Users.Update(user);
+      await _db.SaveChangesAsync();
+      return true;
+    }
+    
+    
   }
 }

--- a/backend/SocialNetwork.Repository/Services/IAuthService.cs
+++ b/backend/SocialNetwork.Repository/Services/IAuthService.cs
@@ -6,5 +6,7 @@ namespace SocialNetwork.Repository.Services
     {
         Task<bool> RegisterAsync(RegisterRequest request);
         Task<string?> LoginAsync(LoginRequest request);
+        Task<bool> DeleteAccountAsync(Guid userId);
+        Task<bool> EditProfileAsync(Guid userId, EditProfileRequest request);
     }
 }

--- a/backend/SocialNetwork.Test/Services/AuthServiceTests.cs
+++ b/backend/SocialNetwork.Test/Services/AuthServiceTests.cs
@@ -1,37 +1,64 @@
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration; // Add this
+using Microsoft.Extensions.Configuration;
 using SocialNetwork.Entity.Models;
 using SocialNetwork.Repository.Services;
 using Xunit;
+using MockQueryable.Moq; 
 
 namespace SocialNetwork.Test.Services
 {
     public class AuthServiceTests
     {
-        private AuthService CreateService(string dbName)
+        private static Mock<DbSet<User>> CreateMockDbSet(List<User> users)
         {
-            var options = new DbContextOptionsBuilder<SocialNetworkDbContext>()
-                .UseInMemoryDatabase(databaseName: dbName)
-                .Options;
-            var context = new SocialNetworkDbContext(options);
+            var mockSet = users.BuildMockDbSet();
 
-            // Mock IConfiguration with in-memory data for Jwt settings
-            var config = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>
+            mockSet.Setup(m => m.Remove(It.IsAny<User>()))
+                .Callback<User>(u => users.Remove(u));
+
+            mockSet.Setup(m => m.Update(It.IsAny<User>()))
+                .Callback<User>(u => { /* no-op */ });
+
+            mockSet.Setup(m => m.Add(It.IsAny<User>()))
+                .Callback<User>(u => users.Add(u));
+
+            mockSet.Setup(m => m.FindAsync(It.IsAny<object[]>()))
+                .ReturnsAsync((object[] ids) =>
                 {
-                    { "Jwt:Key", "TestKey123456789012345678901234567890" },
-                    { "Jwt:Issuer", "testissuer" },
-                    { "Jwt:Audience", "testaudience" }
-                })
-                .Build();
+                    var id = (Guid)ids[0];
+                    return users.FirstOrDefault(u => u.Id == id);
+                });
 
-            return new AuthService(context, config);
+            return mockSet;
         }
 
-        [Fact]
+        private static IConfiguration CreateTestConfig()
+        {
+            return new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+            { "Jwt:Key", "TestKey123456789012345678901234567890" },
+            { "Jwt:Issuer", "testissuer" },
+            { "Jwt:Audience", "testaudience" }
+                })
+                .Build();
+        }
+
+        private AuthService CreateMockedService(List<User> users)
+        {
+            var mockSet = CreateMockDbSet(users);
+            var mockContext = new Mock<SocialNetworkDbContext>(new DbContextOptions<SocialNetworkDbContext>());
+            mockContext.Setup(c => c.Users).Returns(mockSet.Object);
+            mockContext.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            return new AuthService(mockContext.Object, CreateTestConfig());
+        }
+
+           [Fact]
         public async Task RegisterAsync_AddsUser_WhenUsernameIsUnique()
         {
-            var service = CreateService(nameof(RegisterAsync_AddsUser_WhenUsernameIsUnique));
+            var users = new List<User>();
+            var service = CreateMockedService(users);
             var request = new RegisterRequest { Username = "user", Password = "Pass123!", Email = "user@example.com" };
 
             var result = await service.RegisterAsync(request);
@@ -42,9 +69,10 @@ namespace SocialNetwork.Test.Services
         [Fact]
         public async Task RegisterAsync_ReturnsFalse_WhenUsernameExists()
         {
-            var service = CreateService(nameof(RegisterAsync_ReturnsFalse_WhenUsernameExists));
+            var user = new User { Username = "duplicate", Email = "duplicate@example.com" };
+            var users = new List<User> { user };
+            var service = CreateMockedService(users);
             var request = new RegisterRequest { Username = "duplicate", Password = "Pass123!", Email = "duplicate@example.com" };
-            await service.RegisterAsync(request);
 
             var result = await service.RegisterAsync(request);
 
@@ -54,9 +82,9 @@ namespace SocialNetwork.Test.Services
         [Fact]
         public async Task LoginAsync_ReturnsToken_WhenCredentialsAreValid()
         {
-            var service = CreateService(nameof(LoginAsync_ReturnsToken_WhenCredentialsAreValid));
-            var register = new RegisterRequest { Username = "user", Password = "Pass123!", Email = "user@example.com" };
-            await service.RegisterAsync(register);
+            var user = new User { Id = Guid.NewGuid(), Username = "user", Password = "Pass123!", Email = "user@example.com" };
+            var users = new List<User> { user };
+            var service = CreateMockedService(users);
 
             var login = new LoginRequest { Username = "user", Password = "Pass123!" };
             var token = await service.LoginAsync(login);
@@ -67,12 +95,65 @@ namespace SocialNetwork.Test.Services
         [Fact]
         public async Task LoginAsync_ReturnsNull_WhenCredentialsAreInvalid()
         {
-            var service = CreateService(nameof(LoginAsync_ReturnsNull_WhenCredentialsAreInvalid));
-            var login = new LoginRequest { Username = "nouser", Password = "nopass123!" };
+            var users = new List<User>();
+            var service = CreateMockedService(users);
 
+            var login = new LoginRequest { Username = "nouser", Password = "nopass123!" };
             var token = await service.LoginAsync(login);
 
             Assert.Null(token);
+        }
+
+
+        [Fact]
+        public async Task DeleteAccountAsync_RemovesUser_WhenUserExists()
+        {
+            var user = new User { Id = Guid.NewGuid(), Username = "user" };
+            var users = new List<User> { user };
+            var service = CreateMockedService(users);
+
+            var result = await service.DeleteAccountAsync(user.Id);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task DeleteAccountAsync_ReturnsFalse_WhenUserDoesNotExist()
+        {
+            var users = new List<User>();
+            var service = CreateMockedService(users);
+
+            var result = await service.DeleteAccountAsync(Guid.NewGuid());
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task EditProfileAsync_UpdatesUser_WhenUserExists()
+        {
+            var user = new User { Id = Guid.NewGuid(), Username = "user", Email = "old@example.com", Password = "oldpass" };
+            var users = new List<User> { user };
+            var service = CreateMockedService(users);
+
+            var editRequest = new EditProfileRequest { Username = "updated", Email = "updated@example.com", Password = "newpass" };
+            var result = await service.EditProfileAsync(user.Id, editRequest);
+
+            Assert.True(result);
+            Assert.Equal("updated", user.Username);
+            Assert.Equal("updated@example.com", user.Email);
+            Assert.Equal("newpass", user.Password);
+        }
+
+        [Fact]
+        public async Task EditProfileAsync_ReturnsFalse_WhenUserDoesNotExist()
+        {
+            var users = new List<User>();
+            var service = CreateMockedService(users);
+
+            var editRequest = new EditProfileRequest { Username = "updated" };
+            var result = await service.EditProfileAsync(Guid.NewGuid(), editRequest);
+
+            Assert.False(result);
         }
     }
 }

--- a/backend/SocialNetwork.Test/SocialNetwork.Test.csproj
+++ b/backend/SocialNetwork.Test/SocialNetwork.Test.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MockQueryable.Moq" Version="10.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
## Edit and delete endpoints

- Added authorized edit profile endpoint to AuthController, does not work to test out in swagger since there is no way to provide the token right now
- Added authorized delete account and unauthorized delete account by id endpoint. The unauthorized one is only for development and should be removed or fixed later.
- Added tests for edit and delete in both AuthServiceTests and AuthControllerTests
- Made sure all tests uses mocked data instead
- Added MockQueryable.Moq package for testing
- Fixed warnings for possible null values in Auth related files