### PR TITLE
Added token authorization to swagger

### DIFF
--- a/backend/SocialNetwork.API/BearerSecuritySchemeTransformer.cs
+++ b/backend/SocialNetwork.API/BearerSecuritySchemeTransformer.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+internal sealed class BearerSecuritySchemeTransformer(
+    IAuthenticationSchemeProvider authenticationSchemeProvider) : IOpenApiDocumentTransformer
+{
+    public async Task TransformAsync(
+        OpenApiDocument document,
+        OpenApiDocumentTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        var authenticationSchemes = await authenticationSchemeProvider.GetAllSchemesAsync();
+
+        if (authenticationSchemes.Any(authScheme => authScheme.Name == "Bearer"))
+        {
+            document.Components ??= new OpenApiComponents();
+            document.Components.SecuritySchemes = new Dictionary<string, IOpenApiSecurityScheme>
+            {
+                ["Bearer"] = new OpenApiSecurityScheme
+                {
+                    Type = SecuritySchemeType.Http,
+                    Scheme = "bearer",
+                    In = ParameterLocation.Header,
+                    BearerFormat = "JWT"
+                }
+            };
+
+            foreach (var operation in document.Paths.Values.SelectMany(path => path.Operations))
+            {
+                operation.Value.Security ??= [];
+                operation.Value.Security.Add(new OpenApiSecurityRequirement
+                {
+                    [new OpenApiSecuritySchemeReference("Bearer", document)] = []
+                });
+            }
+        }
+    }
+}

--- a/backend/SocialNetwork.API/Program.cs
+++ b/backend/SocialNetwork.API/Program.cs
@@ -8,7 +8,6 @@ using SocialNetwork.Repository.Interfaces;
 using SocialNetwork.Repository.Repositories;
 using SocialNetwork.Repository.Services;
 
-
 namespace SocialNetwork.API
 {
     public class Program
@@ -19,8 +18,10 @@ namespace SocialNetwork.API
 
             builder.Services.AddControllers();
             builder.Services.AddEndpointsApiExplorer();
-            builder.Services.AddSwaggerGen();
-
+            builder.Services.AddOpenApi(options =>
+            {
+                options.AddDocumentTransformer<BearerSecuritySchemeTransformer>();
+            });
             builder.Services.AddScoped<IPostService, PostService>();
             builder.Services.AddScoped<IAuthService, AuthService>();
             builder.Services.AddScoped<IFollowsService, FollowService>();
@@ -82,11 +83,14 @@ namespace SocialNetwork.API
 
             builder.Services.AddAuthorization();
             var app = builder.Build();
-
             if (app.Environment.IsDevelopment())
             {
-                app.UseSwagger();
-                app.UseSwaggerUI();
+                app.MapOpenApi();
+                app.UseSwaggerUI(options =>
+                {
+                    options.SwaggerEndpoint("/openapi/v1.json", "v1");
+                    options.RoutePrefix = "swagger";
+                });
             }
 
             app.UseHttpsRedirection();


### PR DESCRIPTION
Added BearerSecuritySchemeTransformer to add the OpenApi security configuration.

Should be able to use endpoints that require authorization in swagger.
Log in and use the token in the modal after pressing this button: 
<img width="175" height="68" alt="image" src="https://github.com/user-attachments/assets/dfebd6ef-f2c3-42b5-b1a0-bcc3c7157940" />


Might need to empty cache in browser for it to work correctly.

