### PR TITLE
/Follow updated authorization and url path

### DIFF
--- a/backend/SocialNetwork.API/Controllers/FollowController.cs
+++ b/backend/SocialNetwork.API/Controllers/FollowController.cs
@@ -53,7 +53,7 @@ public class FollowController : ControllerBase
 
         if (userIdClaim == null || !Guid.TryParse(userIdClaim, out var userId))
         {
-            return Unauthorized("Invalid token");
+            return Unauthorized();
         }
 
         var result = await _followService.GetFollowsAsync(userId);

--- a/backend/SocialNetwork.API/Controllers/FollowController.cs
+++ b/backend/SocialNetwork.API/Controllers/FollowController.cs
@@ -45,11 +45,12 @@ public class FollowController : ControllerBase
         { return Ok(); }
         return BadRequest(result.ErrorMessage);
     }
+
     [Authorize]
-    [HttpGet("get/{id}")]
+    [HttpGet]
     public async Task<IActionResult> GetFollows()
     {
-        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        var userIdClaim = User.FindFirst("UserId")?.Value;
 
         if (userIdClaim == null || !Guid.TryParse(userIdClaim, out var userId))
         {
@@ -58,7 +59,10 @@ public class FollowController : ControllerBase
 
         var result = await _followService.GetFollowsAsync(userId);
 
-        if (result.IsSuccess == true) { return Ok(result.Data); }
+        if (result.IsSuccess)
+        {
+            return Ok(result.Data);
+        }
 
         return BadRequest(result.ErrorMessage);
     }

--- a/backend/SocialNetwork.API/Controllers/FollowController.cs
+++ b/backend/SocialNetwork.API/Controllers/FollowController.cs
@@ -19,11 +19,18 @@ public class FollowController : ControllerBase
         _followService = followsService;
     }
     [Authorize]
-    [HttpPost("{id}")]
+    [HttpPost(":followeeId")]
     public async Task<IActionResult> Follow(Guid followeeId)
     {
+        var userIdClaim = User.FindFirst("UserId")?.Value;
+
+        if (userIdClaim == null || !Guid.TryParse(userIdClaim, out var followerId))
+        {
+            return Unauthorized();
+        }
+
         var result = await _followService.FollowAsync(
-            Guid.NewGuid(), 
+            followerId,
             followeeId
             );
 

--- a/backend/SocialNetwork.API/Controllers/FollowController.cs
+++ b/backend/SocialNetwork.API/Controllers/FollowController.cs
@@ -44,9 +44,9 @@ public class FollowController : ControllerBase
         return BadRequest(result.ErrorMessage);
     }
     [HttpGet("get/{id}")]
-    public async Task<IActionResult> GetFollows(Guid id)
+    public async Task<IActionResult> GetFollows()
     {
-        var result = await _followService.GetFollowsAsync(id);
+        var result = await _followService.GetFollowsAsync();
 
         if (result.IsSuccess == true) { return Ok(result.Data); }
 

--- a/backend/SocialNetwork.API/Controllers/FollowController.cs
+++ b/backend/SocialNetwork.API/Controllers/FollowController.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using SocialNetwork.Entity.Models;
 using SocialNetwork.Repository.Services;
 using System.Reflection.Metadata.Ecma335;
+using System.Security.Claims;
 
 namespace SocialNetwork.API.Controllers;
 
@@ -43,10 +45,18 @@ public class FollowController : ControllerBase
         { return Ok(); }
         return BadRequest(result.ErrorMessage);
     }
+    [Authorize]
     [HttpGet("get/{id}")]
     public async Task<IActionResult> GetFollows()
     {
-        var result = await _followService.GetFollowsAsync();
+        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+        if (userIdClaim == null || !Guid.TryParse(userIdClaim, out var userId))
+        {
+            return Unauthorized();
+        }
+
+        var result = await _followService.GetFollowsAsync(userId);
 
         if (result.IsSuccess == true) { return Ok(result.Data); }
 

--- a/backend/SocialNetwork.API/Controllers/FollowController.cs
+++ b/backend/SocialNetwork.API/Controllers/FollowController.cs
@@ -53,7 +53,7 @@ public class FollowController : ControllerBase
 
         if (userIdClaim == null || !Guid.TryParse(userIdClaim, out var userId))
         {
-            return Unauthorized();
+            return Unauthorized("Invalid token");
         }
 
         var result = await _followService.GetFollowsAsync(userId);

--- a/backend/SocialNetwork.API/Controllers/FollowController.cs
+++ b/backend/SocialNetwork.API/Controllers/FollowController.cs
@@ -40,12 +40,13 @@ public class FollowController : ControllerBase
         return BadRequest(result.ErrorMessage);
 
     }
-    [HttpDelete]
-    public async Task<IActionResult> Unfollow(FollowRequest request)
+    [Authorize]
+    [HttpDelete(":followeeId")]
+    public async Task<IActionResult> Unfollow(Guid followeeId)
     {
         var result = await _followService.UnfollowAsync(
-            request.FollowerId, 
-            request.FolloweeId
+            Guid.NewGuid(), 
+            followeeId
             );
 
         if (result.IsSuccess == true)

--- a/backend/SocialNetwork.API/Controllers/FollowController.cs
+++ b/backend/SocialNetwork.API/Controllers/FollowController.cs
@@ -44,10 +44,14 @@ public class FollowController : ControllerBase
     [HttpDelete(":followeeId")]
     public async Task<IActionResult> Unfollow(Guid followeeId)
     {
-        var result = await _followService.UnfollowAsync(
-            Guid.NewGuid(), 
-            followeeId
-            );
+        var userIdClaim = User.FindFirst("UserId")?.Value;
+
+        if (userIdClaim == null || !Guid.TryParse(userIdClaim, out var followerId))
+        {
+            return Unauthorized();
+        }
+
+        var result = await _followService.UnfollowAsync(followerId, followeeId);
 
         if (result.IsSuccess == true)
         { return Ok(); }

--- a/backend/SocialNetwork.API/Controllers/FollowController.cs
+++ b/backend/SocialNetwork.API/Controllers/FollowController.cs
@@ -18,13 +18,13 @@ public class FollowController : ControllerBase
     {
         _followService = followsService;
     }
-
-    [HttpPost]
-    public async Task<IActionResult> Follow(FollowRequest request)
+    [Authorize]
+    [HttpPost("{id}")]
+    public async Task<IActionResult> Follow(Guid followeeId)
     {
         var result = await _followService.FollowAsync(
-            request.FollowerId, 
-            request.FolloweeId
+            Guid.NewGuid(), 
+            followeeId
             );
 
         if (result.IsSuccess == true)

--- a/backend/SocialNetwork.Repository/Services/FollowService.cs
+++ b/backend/SocialNetwork.Repository/Services/FollowService.cs
@@ -1,4 +1,5 @@
 ﻿using SocialNetwork.API.Models;
+using SocialNetwork.Entity.Models;
 using SocialNetwork.Repository.Interfaces;
 using System;
 using System.Collections.Generic;
@@ -12,7 +13,7 @@ public interface IFollowsService
 {
     Task<Result> FollowAsync(Guid follower, Guid followee);
     Task<Result> UnfollowAsync(Guid follower, Guid followee);
-    Task<Result<Guid[]>> GetFollowsAsync();
+    Task<Result<Guid[]>> GetFollowsAsync(Guid follower);
 }
 public class FollowService : IFollowsService
 {
@@ -46,9 +47,15 @@ public class FollowService : IFollowsService
         }
     }
 
-    public async Task<Result<Guid[]>> GetFollowsAsync()
+    public async Task<Result<Guid[]>> GetFollowsAsync(Guid follower)
     {
-        throw new NotImplementedException();
+        if (follower == Guid.Empty)
+        {
+            return Result<Guid[]>.Failure("Empty user");
+        }
+
+        var follows = await _repository.GetFollowsAsync(follower);
+        return Result<Guid[]>.Success(follows);
     }
 
     public async Task<Result> UnfollowAsync(Guid follower, Guid followee)

--- a/backend/SocialNetwork.Repository/Services/FollowService.cs
+++ b/backend/SocialNetwork.Repository/Services/FollowService.cs
@@ -12,7 +12,7 @@ public interface IFollowsService
 {
     Task<Result> FollowAsync(Guid follower, Guid followee);
     Task<Result> UnfollowAsync(Guid follower, Guid followee);
-    Task<Result<Guid[]>> GetFollowsAsync(Guid follower);
+    Task<Result<Guid[]>> GetFollowsAsync();
 }
 public class FollowService : IFollowsService
 {
@@ -46,15 +46,9 @@ public class FollowService : IFollowsService
         }
     }
 
-    public async Task<Result<Guid[]>> GetFollowsAsync(Guid follower)
+    public async Task<Result<Guid[]>> GetFollowsAsync()
     {
-        if (follower == Guid.Empty)
-        {
-            return Result<Guid[]>.Failure("Empty user");
-        }
-
-        var follows = await _repository.GetFollowsAsync(follower);
-        return Result<Guid[]>.Success(follows);
+        throw new NotImplementedException();
     }
 
     public async Task<Result> UnfollowAsync(Guid follower, Guid followee)

--- a/backend/SocialNetwork.Test/Controllers/FollowControllerTests.cs
+++ b/backend/SocialNetwork.Test/Controllers/FollowControllerTests.cs
@@ -22,7 +22,7 @@ public class FollowControllerTests
     }
 
     [Fact]
-    public async Task Follow_ValidRequest_ReturnsOk()
+    public async Task Follow_ValidTokenAndGuid_ReturnsOk()
     {
         //Arrange
         _followServiceMock.Setup(m =>
@@ -120,7 +120,7 @@ public class FollowControllerTests
             {
                 User = new ClaimsPrincipal(new ClaimsIdentity(new[]
                 {
-                new Claim(ClaimTypes.NameIdentifier, userId.ToString())
+                new Claim("UserId", userId.ToString())
                 }, "TestAuth"))
             }
         };
@@ -161,7 +161,7 @@ public class FollowControllerTests
             {
                 User = new ClaimsPrincipal(new ClaimsIdentity(new[]
                 {
-                    new Claim(ClaimTypes.NameIdentifier, "not-a-valid-guid")
+                    new Claim("UserId", "not-a-valid-guid")
                 }, "TestAuth"))
             }
         };
@@ -174,6 +174,35 @@ public class FollowControllerTests
 
     }
 
+
+    [Fact]
+    public async Task GetFollows_UserFollowsNobody_ReturnsEmptyArray()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        _sut.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+            new Claim("UserId", userId.ToString())
+        }, "TestAuth"))
+            }
+        };
+
+        _followServiceMock
+            .Setup(s => s.GetFollowsAsync(userId))
+            .ReturnsAsync(Result<Guid[]>.Success(Array.Empty<Guid>()));
+
+        // Act
+        var result = await _sut.GetFollows();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var data = Assert.IsType<Guid[]>(okResult.Value);
+        Assert.Empty(data);
+    }
 }
 
 

--- a/backend/SocialNetwork.Test/Controllers/FollowControllerTests.cs
+++ b/backend/SocialNetwork.Test/Controllers/FollowControllerTests.cs
@@ -136,20 +136,44 @@ public class FollowControllerTests
     }
 
     [Fact]
-    public async Task GetFollowsAsync_EmptyGuid_ReturnsBadRequest()
+    public async Task GetFollowsAsync_NoToken_ReturnsUnauthorized()
     {
         // Arrange
-        _followServiceMock
-            .Setup(m => m.GetFollowsAsync(Guid.NewGuid()))
-            .ReturnsAsync(Result<Guid[]>.Failure("Empty user"));
+        _sut.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
 
         // Act
         var result = await _sut.GetFollows();
 
         // Assert
-        var badrequestResult = Assert.IsType<BadRequestObjectResult>(result);
-        Assert.Equal("Empty user", badrequestResult.Value);
+        Assert.IsType<UnauthorizedResult>(result);
     }
+
+    [Fact]
+    public async Task GetFollows_WithInvalidGuidInToken_ReturnsUnauthorized()
+    {
+        // Arrange
+        _sut.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.NameIdentifier, "not-a-valid-guid")
+                }, "TestAuth"))
+            }
+        };
+
+        // Act
+        var result = await _sut.GetFollows();
+
+        // Assert 
+        Assert.IsType<UnauthorizedResult>(result);
+
+    }
+
 }
 
 

--- a/backend/SocialNetwork.Test/Controllers/FollowControllerTests.cs
+++ b/backend/SocialNetwork.Test/Controllers/FollowControllerTests.cs
@@ -111,7 +111,7 @@ public class FollowControllerTests
         var followedUsers = new Guid[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
 
         _followServiceMock
-            .Setup(m => m.GetFollowsAsync())
+            .Setup(m => m.GetFollowsAsync(userId))
             .ReturnsAsync(Result<Guid[]>.Success(followedUsers));
 
         _sut.ControllerContext = new ControllerContext
@@ -134,12 +134,13 @@ public class FollowControllerTests
         Assert.Equal(3, returnedGuids.Length);
         Assert.Equal(followedUsers, returnedGuids);
     }
+
     [Fact]
     public async Task GetFollowsAsync_EmptyGuid_ReturnsBadRequest()
     {
         // Arrange
         _followServiceMock
-            .Setup(m => m.GetFollowsAsync())
+            .Setup(m => m.GetFollowsAsync(Guid.NewGuid()))
             .ReturnsAsync(Result<Guid[]>.Failure("Empty user"));
 
         // Act

--- a/backend/SocialNetwork.Test/Services/FollowsServiceTests.cs
+++ b/backend/SocialNetwork.Test/Services/FollowsServiceTests.cs
@@ -102,7 +102,7 @@ public class FollowsServiceTests
             .ReturnsAsync(followedUsers);
 
         // Act
-        var result = await _sut.GetFollowsAsync();
+        var result = await _sut.GetFollowsAsync(followerId);
 
 
         // Assert
@@ -116,7 +116,7 @@ public class FollowsServiceTests
         var followerId = Guid.Empty;
 
         // Act
-        var result = await _sut.GetFollowsAsync();
+        var result = await _sut.GetFollowsAsync(followerId);
 
         // Assert
         Assert.False(result.IsSuccess);
@@ -133,7 +133,7 @@ public class FollowsServiceTests
             .ReturnsAsync(new Guid[] { });
 
         // Act
-        var result = await _sut.GetFollowsAsync();
+        var result = await _sut.GetFollowsAsync(Guid.NewGuid());
 
         // Assert
         Assert.True(result.IsSuccess);

--- a/backend/SocialNetwork.Test/Services/FollowsServiceTests.cs
+++ b/backend/SocialNetwork.Test/Services/FollowsServiceTests.cs
@@ -102,7 +102,7 @@ public class FollowsServiceTests
             .ReturnsAsync(followedUsers);
 
         // Act
-        var result = await _sut.GetFollowsAsync(followerId);
+        var result = await _sut.GetFollowsAsync();
 
 
         // Assert
@@ -116,7 +116,7 @@ public class FollowsServiceTests
         var followerId = Guid.Empty;
 
         // Act
-        var result = await _sut.GetFollowsAsync(followerId);
+        var result = await _sut.GetFollowsAsync();
 
         // Assert
         Assert.False(result.IsSuccess);
@@ -133,7 +133,7 @@ public class FollowsServiceTests
             .ReturnsAsync(new Guid[] { });
 
         // Act
-        var result = await _sut.GetFollowsAsync(Guid.NewGuid());
+        var result = await _sut.GetFollowsAsync();
 
         // Assert
         Assert.True(result.IsSuccess);


### PR DESCRIPTION
Utilized the jwt token for authorization in Follow endpoint. 

## Post /Follow/:followeeId
Creates a following relationship between the logged in user and the user of the id in the url. 
## Delete /Follow/:followeeId
Unfollows the logged in user from the user of the id in the url.
## Get /Follow
Gets a list every user the logged in user follows.

There is no longer a need to send bodies with calls to /Follow, all info is in the url.