### PR TITLE
77 timeline hook and 78 username instead of guid

### DIFF
--- a/backend/SocialNetwork.API/Controllers/TimelineController.cs
+++ b/backend/SocialNetwork.API/Controllers/TimelineController.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using SocialNetwork.API.Models;
+using SocialNetwork.Entity.Models;
 using SocialNetwork.Repository.Services;
 
 namespace SocialNetwork.API.Controllers
@@ -10,10 +12,12 @@ namespace SocialNetwork.API.Controllers
     public class TimelineController : ControllerBase
     {
         private readonly ITimelineService _timelineService;
+        private readonly SocialNetworkDbContext _db;
 
-        public TimelineController(ITimelineService timelineService)
+        public TimelineController(ITimelineService timelineService, SocialNetworkDbContext db)
         {
             _timelineService = timelineService;
+            _db = db;
         }
 
         [HttpGet]
@@ -21,11 +25,22 @@ namespace SocialNetwork.API.Controllers
         {
             var posts = await _timelineService.GetPostsByUserIdAsync(userId);
 
+            var userIds = posts
+              .SelectMany(p => new[] { p.SenderId, p.ReceiverId })
+              .Distinct()
+              .ToList();
+
+            var users = await _db.Users
+              .Where(u => userIds.Contains(u.Id))
+              .ToDictionaryAsync(u => u.Id, u => u.Username);
+
             var dtos = posts.Select(p => new PostDto
             {
                 Id = p.Id,
                 SenderId = p.SenderId,
+                SenderUsername = users.TryGetValue(p.SenderId, out var sName) ? sName : string.Empty,
                 ReceiverId = p.ReceiverId,
+                ReceiverUsername = users.TryGetValue(p.ReceiverId, out var rName) ? rName : string.Empty,
                 Content = p.Content,
                 CreatedAt = p.CreatedAt
             }).ToList();

--- a/backend/SocialNetwork.API/Models/PostDTO.cs
+++ b/backend/SocialNetwork.API/Models/PostDTO.cs
@@ -6,6 +6,7 @@ namespace SocialNetwork.API.Models
         public Guid SenderId { get; set; }
         public string SenderUsername { get; set; } = string.Empty;
         public Guid ReceiverId { get; set; }
+        public string ReceiverUsername { get; set; } = string.Empty;
         public string Content { get; set; } = string.Empty;
         public DateTime CreatedAt { get; set; }
     }

--- a/backend/SocialNetwork.Test/Controllers/TimelineControllerTests.cs
+++ b/backend/SocialNetwork.Test/Controllers/TimelineControllerTests.cs
@@ -1,12 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using SocialNetwork.Entity.Models;
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Moq;
 using SocialNetwork.API.Controllers;
 using SocialNetwork.API.Models;
+using SocialNetwork.Entity.Models;
 using SocialNetwork.Repository.Services;
-using Moq;
-using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SocialNetwork.Test.Controllers
@@ -14,12 +15,20 @@ namespace SocialNetwork.Test.Controllers
     public class TimelineControllerTests
     {
         private readonly Mock<ITimelineService> _timelineServiceMock;
+        private readonly SocialNetworkDbContext _db;
         private readonly TimelineController _sut;
 
         public TimelineControllerTests()
         {
             _timelineServiceMock = new Mock<ITimelineService>();
-            _sut = new TimelineController(_timelineServiceMock.Object);
+
+            var options = new DbContextOptionsBuilder<SocialNetworkDbContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+
+            _db = new SocialNetworkDbContext(options);
+
+            _sut = new TimelineController(_timelineServiceMock.Object, _db);
         }
 
         [Fact]
@@ -48,7 +57,7 @@ namespace SocialNetwork.Test.Controllers
             Assert.Equal(posts.Count, dtos.Count);
 
             Assert.Equal(posts[0].Id, dtos[0].Id);
-            Assert.Equal(posts[0].SenderId, dtos[0].SenderId);
+            Assert.Equal(posts[0].SenderId, dtos[0].SenderId);            
             Assert.Equal(posts[0].ReceiverId, dtos[0].ReceiverId);
             Assert.Equal(posts[0].Content, dtos[0].Content);
             Assert.Equal(posts[0].CreatedAt, dtos[0].CreatedAt);

--- a/frontend/sass/_postCard.scss
+++ b/frontend/sass/_postCard.scss
@@ -19,6 +19,13 @@
     line-height: 1.5;
   }
 
+  .post-footer {
+    margin-top: 0.8rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
   .sender {
     color: #b8b8ff;
     font-weight: 600;

--- a/frontend/src/hooks/useTimeline.ts
+++ b/frontend/src/hooks/useTimeline.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+
+const BASE_URL = "http://localhost:5148";
+
+export type PostDto = {
+  id: string;
+  senderId: string;
+  recieverId: string;
+  content: string;
+  createdAt: string;
+};
+
+type UseTimelineResult = {
+  posts: PostDto[];
+  isLoading: boolean;
+  error: string | null;
+};
+
+export function useTimeline(userId: string | undefined): UseTimelineResult {
+  const [posts, setPosts] = useState<PostDto[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const loadTimeline = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const res = await fetch(`${BASE_URL}/api/users/${userId}/timeline`);
+
+        if (!res.ok) {
+          throw new Error("Failed to load timeline");
+        }
+
+        const data: PostDto[] = await res.json();
+        setPosts(data);
+      } catch (err) {
+        setError("Could not load timeline.");
+        setPosts([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadTimeline();
+  }, [userId]);
+
+  return { posts, isLoading, error };
+}

--- a/frontend/src/hooks/useTimeline.ts
+++ b/frontend/src/hooks/useTimeline.ts
@@ -5,7 +5,9 @@ const BASE_URL = "http://localhost:5148";
 export type PostDto = {
   id: string;
   senderId: string;
-  recieverId: string;
+  senderUsername: string;
+  receiverId: string;
+  receiverUsername: string;
   content: string;
   createdAt: string;
 };

--- a/frontend/src/hooks/useTimeline.ts
+++ b/frontend/src/hooks/useTimeline.ts
@@ -1,6 +1,5 @@
-import { useEffect, useState } from "react";
-
-const BASE_URL = "http://localhost:5148";
+import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
+import { API } from "../config/api";
 
 export type PostDto = {
   id: string;
@@ -16,6 +15,7 @@ type UseTimelineResult = {
   posts: PostDto[];
   isLoading: boolean;
   error: string | null;
+  setPosts: Dispatch<SetStateAction<PostDto[]>>;
 };
 
 export function useTimeline(userId: string | undefined): UseTimelineResult {
@@ -31,7 +31,7 @@ export function useTimeline(userId: string | undefined): UseTimelineResult {
       setError(null);
 
       try {
-        const res = await fetch(`${BASE_URL}/api/users/${userId}/timeline`);
+        const res = await fetch(API.USERS.TIMELINE(userId));
 
         if (!res.ok) {
           throw new Error("Failed to load timeline");
@@ -50,5 +50,5 @@ export function useTimeline(userId: string | undefined): UseTimelineResult {
     loadTimeline();
   }, [userId]);
 
-  return { posts, isLoading, error };
+  return { posts, isLoading, error, setPosts };
 }

--- a/frontend/src/timeline/PostCard.tsx
+++ b/frontend/src/timeline/PostCard.tsx
@@ -25,20 +25,21 @@ export default function PostCard({
       <Card.Body>
         <div className="post-content">{content}</div>
 
-        <div className="timestamp">{timestamp}</div>
+        <div className="post-footer">
+          <span className="timestamp">{timestamp}</span>
+
+          {canDelete && onDelete && (
+            <Button
+              variant="outline-danger"
+              size="sm"
+              onClick={onDelete}
+              disabled={deleting}
+            >
+              {deleting ? "Deleting..." : "Delete"}
+            </Button>
+          )}
+        </div>
       </Card.Body>
-      <Card.Footer>
-        {canDelete && onDelete && (
-          <Button
-            variant="outline-danger"
-            size="sm"
-            onClick={onDelete}
-            disabled={deleting}
-          >
-            {deleting ? "Deleting..." : "Delete"}
-          </Button>
-        )}
-      </Card.Footer>
     </Card>
   );
 }

--- a/frontend/src/timeline/Timeline.tsx
+++ b/frontend/src/timeline/Timeline.tsx
@@ -44,7 +44,11 @@ export default function Timeline() {
   return (
     <Row className="justify-content-center">
       <Col xs={12}>
-        <h2 className="feed-title">{timelineOwnerName}'s Timeline</h2>
+        <h2 className="feed-title">
+          {posts.length === 0
+            ? "Empty Timeline"
+            : `${timelineOwnerName}'s Timeline`}
+        </h2>
       </Col>
       <Col xs={12} md={8} lg={6} className="feed-list-container">
         <div className="timeline-content">{content}</div>

--- a/frontend/src/timeline/Timeline.tsx
+++ b/frontend/src/timeline/Timeline.tsx
@@ -11,6 +11,11 @@ export default function Timeline() {
 
   const { posts, isLoading, error } = useTimeline(userId);
 
+  const timelineOwnerName =
+    posts.length > 0 && posts[0].receiverUsername
+      ? posts[0].receiverUsername
+      : userId ?? "Timeline";
+
   let content: ReactNode;
 
   if (isLoading) {
@@ -27,7 +32,7 @@ export default function Timeline() {
         {posts.map((post) => (
           <PostCard
             key={post.id}
-            sender={post.senderId}
+            sender={post.senderUsername}
             content={post.content}
             timestamp={new Date(post.createdAt).toLocaleString()}
           />
@@ -39,7 +44,7 @@ export default function Timeline() {
   return (
     <Row className="justify-content-center">
       <Col xs={12}>
-        <h2 className="feed-title">{userId} Timeline</h2>
+        <h2 className="feed-title">{timelineOwnerName}'s Timeline</h2>
       </Col>
       <Col xs={12} md={8} lg={6} className="feed-list-container">
         <div className="timeline-content">{content}</div>

--- a/frontend/src/timeline/Timeline.tsx
+++ b/frontend/src/timeline/Timeline.tsx
@@ -1,51 +1,16 @@
-import React, { ReactNode } from "react";
-import { useEffect } from "react";
-import { useState } from "react";
-import PostCard from "./PostCard";
-import TimelineStatus from "./TimelineStatus";
+import type { ReactNode } from "react";
 import { useParams } from "react-router-dom";
 import { Col, Row } from "react-bootstrap";
 
-type PostDto = {
-  id: string;
-  senderId: string;
-  recieverId: string;
-  content: string;
-  createdAt: string;
-};
-
-const BASE_URL = "http://localhost:5148";
+import PostCard from "./PostCard";
+import TimelineStatus from "./TimelineStatus";
+import { useTimeline } from "../hooks/useTimeline";
 
 export default function Timeline() {
   const { id: userId } = useParams<{ id: string }>();
 
-  const [posts, setPosts] = useState<PostDto[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { posts, isLoading, error } = useTimeline(userId);
 
-  useEffect(() => {
-    if (!userId) return;
-    setIsLoading(true);
-    setError(null);
-
-    fetch(`${BASE_URL}/api/users/${userId}/timeline`)
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error("Failed to load timeline");
-        }
-        return res.json();
-      })
-      .then((data: PostDto[]) => {
-        setPosts(data);
-      })
-      .catch(() => {
-        setError("Could not load timeline.");
-        setPosts([]);
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-  }, [userId]);
   let content: ReactNode;
 
   if (isLoading) {

--- a/frontend/src/timeline/Timeline.tsx
+++ b/frontend/src/timeline/Timeline.tsx
@@ -3,51 +3,21 @@ import { useParams } from "react-router-dom";
 import { Col, Row } from "react-bootstrap";
 import { useDeletePost } from "../hooks/useDeletePost";
 import useCurrentUser from "../hooks/useCurrentUser";
-import { API } from "../config/api";
-
 import PostCard from "./PostCard";
 import TimelineStatus from "./TimelineStatus";
 import { useTimeline } from "../hooks/useTimeline";
 
 export default function Timeline() {
   const { id: userId } = useParams<{ id: string }>();
-
-  const [posts, setPosts] = useState<PostDto[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
+  const { posts, isLoading, error, setPosts } = useTimeline(userId);
   const { userId: currentUserId } = useCurrentUser();
   const { deletePost, loading: deleting, error: deleteError } = useDeletePost();
 
-  useEffect(() => {
+  const timelineOwnerName =
+    posts.length > 0 && posts[0].receiverUsername
+      ? posts[0].receiverUsername
+      : "Timeline";
 
-if (!userId) {
-  setError("No user id provided.");
-  setIsLoading(false);
-  return;
-}
-
-setIsLoading(true);
-setError(null);
-
-fetch(API.USERS.TIMELINE(userId))
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error("Failed to load timeline");
-        }
-        return res.json();
-      })
-       .then((data) => {
-    setPosts(data);
-      })
-      .catch(() => {
-        setError("Could not load timeline.");
-        setPosts([]);
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-  }, [userId]);
   let content: ReactNode;
 
   async function handleDelete(postId: string) {
@@ -74,37 +44,36 @@ fetch(API.USERS.TIMELINE(userId))
     content = (
       <>
         {posts.map((post) => (
-        <PostCard
-          key={post.id}
-          sender={post.senderUsername}
-          content={post.content}
-          timestamp={new Date(post.createdAt).toLocaleString()}
-          canDelete={currentUserId === post.senderId}
-          onDelete={() => handleDelete(post.id)}
-          deleting={deleting}
-        />
+          <PostCard
+            key={post.id}
+            sender={post.senderUsername}
+            content={post.content}
+            timestamp={new Date(post.createdAt).toLocaleString()}
+            canDelete={currentUserId === post.senderId}
+            onDelete={() => handleDelete(post.id)}
+            deleting={deleting}
+          />
         ))}
       </>
     );
   }
-return (
+  return (
     <Row className="justify-content-center">
       <Col xs={12}>
         <div>
-      {deleteError && (
-        <div className="text-danger mb-2 small">{deleteError}</div>
-      )}
-        <h2 className="feed-title">
-          {posts.length === 0
-            ? "Empty Timeline"
-            : `${timelineOwnerName}'s Timeline`}
-        </h2>
+          {deleteError && (
+            <div className="text-danger mb-2 small">{deleteError}</div>
+          )}
+          <h2 className="feed-title">
+            {posts.length === 0
+              ? "Empty Timeline"
+              : `${timelineOwnerName}'s Timeline`}
+          </h2>
         </div>
       </Col>
       <Col xs={12} md={8} lg={6} className="feed-list-container">
         <div className="timeline-content">{content}</div>
       </Col>
     </Row>
-
   );
 }


### PR DESCRIPTION
- Refactors Timeline to use a dedicated `useTimeline` hook for data fetching.
- Integrates delete flow with `useDeletePost` and keeps local state in sync.
- Updates Timeline to display `senderUsername` instead of GUID.
- Shows "Empty Timeline" when there are no posts, with a consistent status UI.
- Aligns PostCard layout so timestamp and delete button are shown together in the footer.


- Closes #77
- Closes #78